### PR TITLE
Compilation errors fix

### DIFF
--- a/Liveness/liveness.cpp
+++ b/Liveness/liveness.cpp
@@ -27,7 +27,7 @@ void Liveness::GenerateLiveInfo(flowgraph::FlowGraph flow_graph) {
     // TODO agarrar la lista de los nodos
     vector<set<temp::Temp>> in, out, def, use;
     set<temp::Temp> _in,_out;
-    auto node_list = flow_graph.node_list;
+    const auto& node_list = flow_graph.node_list;
     for ( auto i = node_list.begin(); i != node_list.end(); ++i ) {
         set<temp::Temp> temp1;
         in.push_back(temp1);
@@ -35,7 +35,7 @@ void Liveness::GenerateLiveInfo(flowgraph::FlowGraph flow_graph) {
         use.push_back((*i)->get_use());
         def.push_back((*i)->get_def());
     }
-
+    
     bool done = false;
     while ( !done ) {
         for ( int i = 0; i < node_list.size(); ++i ) {
@@ -59,5 +59,5 @@ void Liveness::GenerateLiveInfo(flowgraph::FlowGraph flow_graph) {
 }
 
 Liveness::Liveness(flowgraph::FlowGraph flow_graph) {
-    GenerateLiveInfo(flow_graph);
+    GenerateLiveInfo(move(flow_graph));
 }

--- a/Munch/assem.h
+++ b/Munch/assem.h
@@ -29,8 +29,8 @@ struct Oper : public Instruction {
 
     Oper(std::string assm, temp::TempList dst, temp::TempList src, temp::LabelList jumps) : assm(assm), src(src), dst(dst), jumps(jumps) {}
     virtual void print(std::ostream& os, temp::TempMap& temp_map) const override;
-    virtual temp::TempList get_src() { return src; };
-    virtual temp::TempList get_dst() { return dst; };
+    virtual temp::TempList get_src() const { return src; };
+    virtual temp::TempList get_dst() const { return dst; };
 };
 
 struct Label : public Instruction {
@@ -38,8 +38,8 @@ struct Label : public Instruction {
     temp::Label label;
 
     Label(std::string assm, temp::Label label) : assm(assm), label(label) {}
-    virtual temp::TempList get_src() { return temp::TempList(); };
-    virtual temp::TempList get_dst() { return temp::TempList(); };
+    virtual temp::TempList get_src() const { return temp::TempList(); };
+    virtual temp::TempList get_dst() const { return temp::TempList(); };
     virtual void print(std::ostream& os, temp::TempMap& temp_map) const override;
 };
 
@@ -48,8 +48,8 @@ struct Move : public Instruction {
     temp::TempList src, dst;
 
     Move(std::string assm, temp::TempList dst, temp::TempList src) : assm(assm), src(src), dst(dst) {}
-    virtual temp::TempList get_src() { return src; };
-    virtual temp::TempList get_dst() { return dst; };
+    virtual temp::TempList get_src() const { return src; };
+    virtual temp::TempList get_dst() const { return dst; };
     virtual void print(std::ostream& os, temp::TempMap& temp_map) const override;
 };
 


### PR DESCRIPTION
* assem.Instruction and its children classes missmatched their signatures
* FlowGraph can't be copied: it contains a vector<unique_pt<Node>>